### PR TITLE
Fix "The entered emulator (trinity_soap) doesn't exist" after install…

### DIFF
--- a/application/libraries/realms.php
+++ b/application/libraries/realms.php
@@ -24,7 +24,7 @@ class Realms
 	private $hordeRaces;
 	private $allianceRaces;
 
-	private $defaultEmulator = "trinity_soap";
+	private $defaultEmulator = "trinity_rbac_soap";
 
 	public function __construct()
 	{


### PR DESCRIPTION
…ation

Issue fixed where the emulator trinity_soap was not found after an installation.

Screen:
![screenshot 2160](https://user-images.githubusercontent.com/74456323/113411386-eaa55700-93b5-11eb-871d-2544c26db7e1.png)
