### PR TITLE
Fix item description on refreshing page

### DIFF
--- a/application/modules/item/views/ajax.tpl
+++ b/application/modules/item/views/ajax.tpl
@@ -1,8 +1,8 @@
 <script type="text/javascript">
 	$(document).ready(function()
 	{
-		$(".item_bg").html(lang("loading", "item"));
-		
+		$(".item_bg").html("Loading...");
+
 		$.get(Config.URL + "tooltip/" + {$realm} + "/" + {$id}, function(data)
 	 	{
 	 		$(".item_bg").html(data);


### PR DESCRIPTION
- Now will show a Loading... text before item description.
- Now will properly load item description even after refreshing the page.
- It can be considered hack ? maybe idk / anyway if you don't like it don't merge.
- It works like in the video below (with browser disabled cache).


https://user-images.githubusercontent.com/24683355/114308046-27c2c500-9aeb-11eb-98e2-6c82342851af.mp4

