### PR TITLE
Fix character power bars in armory

### DIFF
--- a/application/modules/character/controllers/character.php
+++ b/application/modules/character/controllers/character.php
@@ -170,35 +170,45 @@ class Character extends MX_Controller
 		
 		if($this->realms->getRealm($this->realm)->getEmulator()->hasStats())
 		{
-			// Find out which power field to use
-			switch($this->className)
-			{
-				default:
-					$this->secondBar = "mana";
-					$this->secondBarValue = $this->stats['maxpower1'];
-				break;
+            // Find out which power field to use
+            switch($this->className)
+            {
+                default:
+                    $this->secondBar = "mana";
+                    $this->secondBarValue = $this->stats['maxpower1'];
+                break;
 
-				case "Warrior":
-					$this->secondBar = "rage";
-					$this->secondBarValue = $this->stats['maxpower2'];
-				break;
+                case "Warrior":
+                    $this->secondBar = "rage";
+                    $this->secondBarValue = $this->stats['maxpower2'] / 10;
+                break;
 
-				case "Hunter":
-					$this->secondBar = "focus";
-					$this->secondBarValue = $this->stats['maxpower3'];
-				break;
+                case "Rogue":
+                    $this->secondBar = "energy";
+                    $this->secondBarValue = $this->stats['maxpower4'];
+                break;
 
-				case "Deathknight":
-					$this->secondBar = "runic";
-					$this->secondBarValue = $this->stats['maxpower7'];
-				break;
-			}
-		}
-		else
-		{
-			$this->secondBar = "mana";
-			$this->secondBarValue = lang("unknown", "character");
-		}
+                case "Hunter":
+                    if ($this->stats['maxpower3']){
+                        $this->secondBar = "focus";
+                        $this->secondBarValue = $this->stats['maxpower3'];
+                    } else {
+                        $this->secondBar = "mana";
+                        $this->secondBarValue = $this->stats['maxpower1'];
+                    }
+                break;
+
+                case "Death knight":
+                    $this->secondBar = "runic";
+                    $this->secondBarValue = $this->stats['maxpower7'] / 10;
+                break;
+            }
+        }
+        else
+        {
+            $this->secondBar = "mana";
+            $this->secondBarValue = lang("unknown", "character");
+        }
 
 		// Load the items
 		$items = $this->armory_model->getItems();


### PR DESCRIPTION
-This will fix the power bars for respective classes in armory : 
- Mana / Focus for Hunters
- Energie for Rogues
- Rage for Warriors
- Runic Power for Death Knights.
--And yes this is commit worthy for srp6 too.

![Captureqw](https://user-images.githubusercontent.com/24683355/114321773-2a421080-9b25-11eb-9af5-8f4859cc585e.JPG)


