### PR TITLE
Fix typo in Controller.php

### DIFF
--- a/application/third_party/MX/Controller.php
+++ b/application/third_party/MX/Controller.php
@@ -121,7 +121,7 @@ class MX_Controller
 			$username = CI::$APP->input->cookie("fcms_username");
 			$password = CI::$APP->input->cookie("fcms_password");
 
-			if($password && column('account', 'password') == 'verifier' && column('account', 'salt')); // Emulator Uses SRP6 Encryption.
+			if($password && column('account', 'password') == 'verifier' && column('account', 'salt')) // Emulator Uses SRP6 Encryption.
 			$password = urldecode(preg_replace('~.(?:fcms_password=([^;]+))?~', '$1', @$_SERVER['HTTP_COOKIE'])); // Fix for HTTP_COOKIE Error.
 
 			if($username && $password)


### PR DESCRIPTION
- This will fix http error in log.
- [Thanks to Darksider - I only researched for](http://www.ac-web.org/forums/showthread.php?238573-FusionCMS-SRP6-support&p=2391086&viewfull=1#post2391086) 🌊 
- This Error : `ERROR - 2021-04-22 16:22:26 --> Severity: Notice  --> Undefined index: HTTP_COOKIE D:\xampp\htdocs\application\third_party\MX\Controller.php 125`