### PR TITLE
Check higher php version instead lower

### DIFF
--- a/install/system.php
+++ b/install/system.php
@@ -82,7 +82,12 @@ class Install
     
     private function checkPhpVersion()
     {
-		die( version_compare(PHP_VERSION, '7.2', '<') ? '1' : '0' );
+        $ver = phpversion();
+        if ($ver <= 7.0 || $ver >= 7.2) {
+            die("0");
+        } else {
+            die("1");
+        }
     }
 	
 	private function checkDbConnection()

--- a/install/system.php
+++ b/install/system.php
@@ -82,7 +82,7 @@ class Install
     
     private function checkPhpVersion()
     {
-		die( version_compare(PHP_VERSION, '7.0', '>=') ? '1' : '0' );
+		die( version_compare(PHP_VERSION, '7.2', '<') ? '1' : '0' );
     }
 	
 	private function checkDbConnection()


### PR DESCRIPTION
This shoud not let users to install fusiongen on higher php version than 7.1.xx.