### PR TITLE
Updated Readme.md with Website Link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -72,3 +72,7 @@ This project exists thanks to:
 
 - **[Jesper Lindström](https://github.com/jesperlindstrom)** (FusionCMS)
 - **The [FusionGen developers and contributors](https://github.com/FusionGen/FusionGEN/graphs/contributors)**
+
+## Website
+
+**[FusionGen.net](https://fusiongen.net/)**


### PR DESCRIPTION
The whole Github Page is missing the website link. I wanted to lookup the website, that's why I thought I'll update the readme real quick.