### PR TITLE
Still log errors even while in production or test environments

### DIFF
--- a/index.php
+++ b/index.php
@@ -32,7 +32,7 @@ if(file_exists("install") && !file_exists("install/.lock"))
  *---------------------------------------------------------------
  *
  * Different environments will require different levels of error reporting.
- * By default development will show errors but testing and live will hide them.
+ * By default development will show errors but testing and production will hide them.
  */
 
 if (defined('ENVIRONMENT'))
@@ -46,7 +46,8 @@ if (defined('ENVIRONMENT'))
 	
 		case 'testing':
 		case 'production':
-			error_reporting(0);
+			error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
+			ini_set('display_errors', '0');
 		break;
 
 		default:


### PR DESCRIPTION
Still log important errors even while in production or test environments, but just hide them.

> Note:
> You're strongly advised to use error logging in place of error displaying on production web sites.

```
; Common Values:
;   E_ALL (Show all errors, warnings and notices including coding standards.)
;   E_ALL & ~E_NOTICE  (Show all errors, except for notices)
;   E_ALL & ~E_NOTICE & ~E_STRICT  (Show all errors, except for notices and coding standards warnings.)
;   E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR  (Show only errors)
; Default Value: E_ALL
; Development Value: E_ALL
; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
; https://php.net/error-reporting
```