### PR TITLE
Bump php_version_max to 8.3.1

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -23,7 +23,7 @@ $zip_success = false;
 $xml_success = false;
 
 $php_version_min = "8.0.0";
-$php_version_max = "8.3.0";
+$php_version_max = "8.3.1";
 $current_php_version = phpversion();
 
 if ($current_php_version <= $php_version_max && $current_php_version >= $php_version_min) {


### PR DESCRIPTION
Tested on PHP 8.3 (8.3.1) VS16 x64 Thread Safe (2023-Dec-20 14:24:44)
Shoud not be problems.

Close: https://github.com/FusionGen/FusionGEN/issues/282

![Captură de ecran 2024-01-15 022103](https://github.com/FusionGen/FusionGEN/assets/24683355/2efa5628-cd9e-4aa6-8269-856fb5cd1950)
![Captură de ecran 2024-01-15 015543](https://github.com/FusionGen/FusionGEN/assets/24683355/03d6a40c-a106-4842-ac2b-b3727256137c)
![Captură de ecran 2024-01-15 022458](https://github.com/FusionGen/FusionGEN/assets/24683355/044452a7-3179-479c-9fa4-ab6fcd55f3ca)
