### PR TITLE
Locking the installer

### DIFF
--- a/install/do_database.php
+++ b/install/do_database.php
@@ -1,4 +1,9 @@
 <?php
+if(file_exists(".lock"))
+{
+	header("HTTP/1.1 403 Forbidden" );
+	die();
+}
 
 set_time_limit(600);
 

--- a/install/do_general.php
+++ b/install/do_general.php
@@ -1,4 +1,10 @@
 <?php
+if(file_exists(".lock"))
+{
+	header("HTTP/1.1 403 Forbidden" );
+	die();
+}
+
 ini_set('set_time_limit', 30);
 
 if (isset($_POST)) {

--- a/install/do_owner.php
+++ b/install/do_owner.php
@@ -1,4 +1,10 @@
 <?php
+if(file_exists(".lock"))
+{
+	header("HTTP/1.1 403 Forbidden" );
+	die();
+}
+
 ini_set('max_execution_time', 30);
 include('../application/config/database.php');
 

--- a/install/do_realms.php
+++ b/install/do_realms.php
@@ -4,6 +4,7 @@ if(file_exists(".lock"))
 	header("HTTP/1.1 403 Forbidden" );
 	die();
 }
+
 class Realms
 {
     private $db;

--- a/install/do_realms.php
+++ b/install/do_realms.php
@@ -1,4 +1,9 @@
 <?php
+if(file_exists(".lock"))
+{
+	header("HTTP/1.1 403 Forbidden" );
+	die();
+}
 class Realms
 {
     private $db;


### PR DESCRIPTION
Locking the Installer. Even with .lock file a attacker can send simply POST Requests on these files to take ownership of the server if install folder is still reachable.